### PR TITLE
Fix NullPointerException in UserService.findById

### DIFF
--- a/src/main/java/com/example/controller/UserController.java
+++ b/src/main/java/com/example/controller/UserController.java
@@ -2,6 +2,7 @@ package com.example.controller;
 
 import com.example.model.User;
 import com.example.service.UserService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -15,8 +16,10 @@ public class UserController {
     }
 
     @GetMapping("/{id}")
-    public User getUser(@PathVariable Long id) {
-        return userService.findById(id);
+    public ResponseEntity<User> getUser(@PathVariable Long id) {
+        return userService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping

--- a/src/main/java/com/example/service/UserService.java
+++ b/src/main/java/com/example/service/UserService.java
@@ -4,6 +4,8 @@ import com.example.model.User;
 import com.example.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 public class UserService {
 
@@ -13,9 +15,8 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-    // BUG: This throws NullPointerException when user is not found
-    public User findById(Long id) {
-        return userRepository.findById(id).get();
+    public Optional<User> findById(Long id) {
+        return userRepository.findById(id);
     }
 
     public java.util.List<User> findAll() {


### PR DESCRIPTION
## Summary

- Changed `UserService.findById()` to return `Optional<User>` instead of calling `.get()` on the repository result
- Updated `UserController.getUser()` to return `ResponseEntity<User>`, mapping to 200 OK when found or 404 Not Found when absent

Closes #1

## Test plan

- [ ] Call `GET /api/users/{id}` with an existing ID → returns 200 with user JSON
- [ ] Call `GET /api/users/{id}` with a non-existent ID → returns 404 (no stack trace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)